### PR TITLE
feat: free outdated async only when pure-data payload matches

### DIFF
--- a/LKM-Source/Makefile
+++ b/LKM-Source/Makefile
@@ -1,5 +1,5 @@
 obj-m := rekernel.o
-rekernel-y := rekernel_main.o rekernel_netlink.o rekernel_binder.o rekernel_signal.o rekernel_netfilter.o
+rekernel-y := rekernel_main.o rekernel_netlink.o rekernel_binder.o rekernel_binder_alloc.o rekernel_signal.o rekernel_netfilter.o
 ifdef REKERNEL_VERSION
 ccflags-y += -DREKERNEL_VERSION=\"$(REKERNEL_VERSION)\"
 endif

--- a/LKM-Source/rekernel_binder.c
+++ b/LKM-Source/rekernel_binder.c
@@ -6,21 +6,26 @@
  *              alloc/preset/reply/transaction emit events when a frozen target
  *              is about to be woken; a live kprobe on binder_proc_transaction
  *              (CLEAN_UP_ASYNC_BINDER) frees superseded outdated async
- *              transactions. Non-exported binder symbols are resolved via a
- *              transient kprobe on kallsyms_lookup_name.
+ *              transactions when identity and pure-data payload match.
+ *              Non-exported binder symbols are resolved via a transient
+ *              kprobe on kallsyms_lookup_name; Linux < 6.0 uses a local
+ *              binder buffer copy helper instead of binder_alloc_copy_from_buffer.
  */
 #include <linux/version.h>
 #include <linux/uaccess.h>
 #include <linux/slab.h>
 #include <linux/list.h>
 #include <linux/kprobes.h>
+#include <linux/string.h>
 #include <trace/hooks/binder.h>
 #include <../android/binder_internal.h>
 #include "rekernel_internal.h"
+#include "rekernel_binder_alloc.h"
 
 static unsigned long (*re_kallsyms_lookup_name)(const char* name);
 static void (*re_kernel_transaction_buffer_release)(struct binder_proc* proc, struct binder_thread* thread, struct binder_buffer* buffer, binder_size_t off_end_offset, bool is_failure);
 static void (*re_kernel_alloc_free_buf)(struct binder_alloc* alloc, struct binder_buffer* buffer);
+static int (*re_kernel_alloc_copy_from_buffer)(struct binder_alloc* alloc, void* dest, struct binder_buffer* buffer, binder_size_t buffer_offset, size_t bytes);
 static struct binder_stats(*re_kernel_stats);
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0))
@@ -202,6 +207,38 @@ __releases(&node->lock)
 	spin_unlock(&node->lock);
 }
 
+/* Compare pure-data binder buffer payload for free-first matching. */
+static bool binder_buffer_data_equal(struct binder_proc* proc,
+	struct binder_buffer* b1, struct binder_buffer* b2)
+{
+	size_t pos, chunk, total;
+	u8 c1[64];
+	u8 c2[64];
+
+	if (!proc || !b1 || !b2 || !re_kernel_alloc_copy_from_buffer)
+		return false;
+	if (b1->data_size != b2->data_size)
+		return false;
+	if (b1->offsets_size != 0 || b2->offsets_size != 0)
+		return false;
+
+	total = b1->data_size;
+	pos = 0;
+	while (pos < total) {
+		chunk = total - pos;
+		if (chunk > sizeof(c1))
+			chunk = sizeof(c1);
+		if (re_kernel_alloc_copy_from_buffer(&proc->alloc, c1, b1, pos, chunk))
+			return false;
+		if (re_kernel_alloc_copy_from_buffer(&proc->alloc, c2, b2, pos, chunk))
+			return false;
+		if (memcmp(c1, c2, chunk))
+			return false;
+		pos += chunk;
+	}
+	return true;
+}
+
 static bool binder_can_update_transaction(struct binder_transaction* t1, struct binder_transaction* t2)
 {
 	if ((t1->flags & t2->flags & TF_ONE_WAY) != TF_ONE_WAY || !t1->to_proc || !t2->to_proc)
@@ -210,7 +247,7 @@ static bool binder_can_update_transaction(struct binder_transaction* t1, struct 
 		t1->flags == t2->flags && t1->buffer->pid == t2->buffer->pid &&
 		t1->buffer->target_node->ptr == t2->buffer->target_node->ptr &&
 		t1->buffer->target_node->cookie == t2->buffer->target_node->cookie)
-		return true;
+		return binder_buffer_data_equal(t1->to_proc, t1->buffer, t2->buffer);
 	return false;
 }
 
@@ -351,8 +388,14 @@ int __nocfi register_kp(void) {
 	re_kernel_transaction_buffer_release = (void*)re_kallsyms_lookup_name("binder_transaction_buffer_release");
 	re_kernel_alloc_free_buf = (void*)re_kallsyms_lookup_name("binder_alloc_free_buf");
 	re_kernel_stats = (void*)re_kallsyms_lookup_name("binder_stats");
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 0, 0)
+	re_kernel_alloc_copy_from_buffer = rekernel_binder_copy_from_buffer;
+#else
+	re_kernel_alloc_copy_from_buffer = (void*)re_kallsyms_lookup_name("binder_alloc_copy_from_buffer");
+#endif
 
-	if (re_kernel_transaction_buffer_release == NULL || re_kernel_alloc_free_buf == NULL || re_kernel_stats == NULL) {
+	if (re_kernel_transaction_buffer_release == NULL || re_kernel_alloc_free_buf == NULL ||
+	    re_kernel_alloc_copy_from_buffer == NULL || re_kernel_stats == NULL) {
 		rc = -EINVAL;
 		pr_err("register kprobe kallsyms_lookup_name failed, rc=%d\n", rc);
 		return rc;

--- a/LKM-Source/rekernel_binder_alloc.c
+++ b/LKM-Source/rekernel_binder_alloc.c
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) Sakion Team. All rights reserved.
+ *
+ * File name: rekernel_binder_alloc.c
+ * Description: Legacy binder buffer copy for Linux < 6.0 (5.10 / 5.15).
+ *              Ported from android14-6.1 drivers/android/binder_alloc.c
+ *              (get_page / buffer_size / check_buffer / do_buffer_copy).
+ *              Newer kernels use in-kernel binder_alloc_copy_from_buffer.
+ */
+
+#include <linux/kernel.h>
+#include <linux/string.h>
+#include <linux/mm.h>
+#include <linux/highmem.h>
+#include <linux/list.h>
+#include <linux/err.h>
+#include <linux/version.h>
+#include "rekernel_binder_alloc.h"
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 0, 0)
+
+static inline void rekernel_memcpy_from_page(char *to, struct page *page,
+	size_t offset, size_t len)
+{
+	char *from;
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0)
+	from = kmap_local_page(page);
+	memcpy(to, from + offset, len);
+	kunmap_local(from);
+#else
+	from = kmap_atomic(page);
+	memcpy(to, from + offset, len);
+	kunmap_atomic(from);
+#endif
+}
+
+static struct binder_buffer *rekernel_binder_buffer_next(struct binder_buffer *buffer)
+{
+	return list_entry(buffer->entry.next, struct binder_buffer, entry);
+}
+
+static size_t rekernel_binder_alloc_buffer_size(struct binder_alloc *alloc,
+	struct binder_buffer *buffer)
+{
+	if (list_is_last(&buffer->entry, &alloc->buffers))
+		return (size_t)((uintptr_t)alloc->buffer + alloc->buffer_size -
+			(uintptr_t)buffer->user_data);
+	return (size_t)((uintptr_t)rekernel_binder_buffer_next(buffer)->user_data -
+		(uintptr_t)buffer->user_data);
+}
+
+static inline bool rekernel_check_buffer(struct binder_alloc *alloc,
+	struct binder_buffer *buffer, binder_size_t offset, size_t bytes)
+{
+	size_t buffer_size = rekernel_binder_alloc_buffer_size(alloc, buffer);
+
+	return buffer_size >= bytes &&
+		offset <= buffer_size - bytes &&
+		IS_ALIGNED(offset, sizeof(u32)) &&
+		!buffer->free &&
+		(!buffer->allow_user_free || !buffer->transaction);
+}
+
+static struct page *rekernel_binder_alloc_get_page(struct binder_alloc *alloc,
+	struct binder_buffer *buffer, binder_size_t buffer_offset, pgoff_t *pgoffp)
+{
+	binder_size_t buffer_space_offset = buffer_offset +
+		((uintptr_t)buffer->user_data - (uintptr_t)alloc->buffer);
+	pgoff_t pgoff = buffer_space_offset & ~PAGE_MASK;
+	size_t index = buffer_space_offset >> PAGE_SHIFT;
+	struct binder_lru_page *lru_page;
+
+	lru_page = &alloc->pages[index];
+	*pgoffp = pgoff;
+	return lru_page->page_ptr;
+}
+
+static int rekernel_binder_alloc_do_buffer_copy(struct binder_alloc *alloc,
+	bool to_buffer, struct binder_buffer *buffer,
+	binder_size_t buffer_offset, void *ptr, size_t bytes)
+{
+	if (!rekernel_check_buffer(alloc, buffer, buffer_offset, bytes))
+		return -EINVAL;
+
+	while (bytes) {
+		unsigned long size;
+		struct page *page;
+		pgoff_t pgoff;
+
+		page = rekernel_binder_alloc_get_page(alloc, buffer, buffer_offset, &pgoff);
+		size = min_t(size_t, bytes, PAGE_SIZE - pgoff);
+		if (to_buffer)
+			return -EINVAL;
+		else
+			rekernel_memcpy_from_page(ptr, page, pgoff, size);
+		bytes -= size;
+		ptr = (u8 *)ptr + size;
+		buffer_offset += size;
+	}
+	return 0;
+}
+
+int rekernel_binder_copy_from_buffer(struct binder_alloc *alloc, void *dest,
+	struct binder_buffer *buffer, binder_size_t buffer_offset, size_t bytes)
+{
+	return rekernel_binder_alloc_do_buffer_copy(alloc, false, buffer,
+		buffer_offset, dest, bytes);
+}
+
+#else
+
+static int rekernel_binder_alloc_legacy_unused __maybe_unused;
+
+#endif

--- a/LKM-Source/rekernel_binder_alloc.h
+++ b/LKM-Source/rekernel_binder_alloc.h
@@ -1,0 +1,13 @@
+#ifndef REKERNEL_BINDER_ALLOC_H
+#define REKERNEL_BINDER_ALLOC_H
+
+#include <linux/types.h>
+#include <linux/version.h>
+#include <../android/binder_internal.h>
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 0, 0)
+int rekernel_binder_copy_from_buffer(struct binder_alloc *alloc, void *dest,
+	struct binder_buffer *buffer, binder_size_t buffer_offset, size_t bytes);
+#endif
+
+#endif


### PR DESCRIPTION
binder_can_update_transaction now also compares pure-data buffer payload (offsets_size == 0). Linux < 6.0 uses a local copy helper ported from android14-6.1 binder_alloc; 6.0+ uses the in-kernel binder_alloc_copy_from_buffer. Keeps free-second behavior.